### PR TITLE
Add MySQL privilege SERVICE_CONNECTION_ADMIN

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -122,6 +122,7 @@ __grants__ = [
     "SELECT",
     "SET USER",  # MariaDB since 10.5.2
     "SET_USER_ID",
+    "SERVICE_CONNECTION_ADMIN", # MySQL since 8.0.14 
     "SHOW DATABASES",
     "SHOW VIEW",
     "SHUTDOWN",


### PR DESCRIPTION
### What does this PR do?

Add MySQL dynamic privilege `SERVICE_CONNECTION_ADMIN` that was introduced in MySQL 8.0.14.

See:
- https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-14.html
- https://dev.mysql.com/doc/refman/8.0/en/administrative-connection-interface.html

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
`mysql_grants.present` does not support `SERVICE_CONNECTION_ADMIN`

### New Behavior
`mysql_grants.present` supports `SERVICE_CONNECTION_ADMIN`

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
